### PR TITLE
fix sticky bug

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1,6 +1,6 @@
 body {
     position: absolute;
-    height: 100%;
+    /* height: 100%; */
     width: 100%;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
When the page was too long, at some point the sticky navbar stops being
sticky and scroll with the page(hidden). The bug caused by giving `body`
height of 100% although the page was longer. By removing `height:100%`
from the body element, the bug was fixed.